### PR TITLE
Moved markdown toggle to toolbar position, misc. other style changes

### DIFF
--- a/examples/editor/public/icons/LICENSE.md
+++ b/examples/editor/public/icons/LICENSE.md
@@ -3,3 +3,9 @@ https://icons.getbootstrap.com
 
 Licensed under MIT license
 https://github.com/twbs/icons/blob/main/LICENSE.md
+
+Public Domain
+
+The Markdown Mark
+https://github.com/dcurtis/markdown-mark/blob/master/LICENSE
+Modified by Bingdong Li on 2025-02-04.

--- a/examples/editor/public/icons/markdown.svg
+++ b/examples/editor/public/icons/markdown.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="208"
+     height="128"
+     viewBox="0 0 208 128">
+    <path d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z" />
+    <script xmlns="" />
+</svg>

--- a/examples/editor/src/Editor.tsx
+++ b/examples/editor/src/Editor.tsx
@@ -206,7 +206,6 @@ export default function Milkup() {
       <HistoryPlugin />
       <CodeHighlightPlugin />
       <TreeViewPlugin />
-      <MarkdownAction shouldPreserveNewLinesInMarkdown={true} />
     </LexicalComposer>
   );
 }

--- a/examples/editor/src/Editor.tsx
+++ b/examples/editor/src/Editor.tsx
@@ -28,7 +28,6 @@ import TreeViewPlugin from "./plugins/TreeViewPlugin";
 
 import "./lexical-styling.css";
 import ToolbarPlugin from "./plugins/ToolbarPlugin";
-import MarkdownAction from "./plugins/MarkdownAction";
 import CodeHighlightPlugin from "./plugins/CodeHighlightPlugin";
 import EquationsPlugin from "../../../packages/milkup-equations/src/EquationsPlugin";
 import {
@@ -174,11 +173,13 @@ export default function Milkup() {
         {initialConfig.editable && <ToolbarPlugin />}
         <div className="editor-inner">
           <RichTextPlugin
-            // @ts-ignore
             contentEditable={
               <div className="editor-scroller">
                 <div className="editor-input" ref={onRef}>
+                  {/*
+                  // @ts-expect-error Probably caused by React version differences between examples/editor and milkup packages. */}
                   <ContentEditable
+                    aria-placeholder="Explore!"
                     placeholder={
                       <div className="editor-placeholder">Explore!</div>
                     }

--- a/examples/editor/src/Editor.tsx
+++ b/examples/editor/src/Editor.tsx
@@ -201,7 +201,7 @@ export default function Milkup() {
           <EquationsPlugin />
           <YouTubePlugin />
           <AutoEmbedPlugin />
-          <ParagraphPlugin trailingLBMode="paragraph" />
+          <ParagraphPlugin trailingLBMode="remove" />
         </div>
       </div>
       <HistoryPlugin />

--- a/examples/editor/src/lexical-styling.css
+++ b/examples/editor/src/lexical-styling.css
@@ -574,6 +574,13 @@ i.check-list {
   background-image: url(/icons/list-check.svg);
 }
 
+i.markdown {
+  background-image: url(/icons/markdown.svg);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+}
+
 .icon.plus {
   background-image: url(/icons/plus.svg);
 }

--- a/examples/editor/src/lexical-styling.css
+++ b/examples/editor/src/lexical-styling.css
@@ -600,3 +600,7 @@ i.markdown {
 .icon.youtube {
   background-image: url(/icons/youtube.svg);
 }
+
+.editor-placeholder {
+  margin-left: 16px;
+}

--- a/examples/editor/src/plugins/MarkdownAction.tsx
+++ b/examples/editor/src/plugins/MarkdownAction.tsx
@@ -1,58 +1,39 @@
-import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import React, { useCallback } from "react";
-import { $createTextNode, $getRoot } from "lexical";
+import { $createTextNode, $getRoot, LexicalEditor } from "lexical";
 import { $createCodeNode, $isCodeNode } from "@lexical/code";
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
 } from "@lexical/markdown";
 import { TRANSFORMERS } from "./transformers";
-import Button from "../../../../packages/core/ui/button";
 
-export default function MarkdownAction({
-  shouldPreserveNewLinesInMarkdown,
-}: {
+export type MarkdownProps = {
   shouldPreserveNewLinesInMarkdown: boolean;
-}): JSX.Element {
-  const [editor] = useLexicalComposerContext();
-  /* other consts like isEmpty, so on that may be useful */
+}
 
-  const markdownToggle = useCallback(() => {
-    editor.update(() => {
-      const root = $getRoot();
-      const firstChild = root.getFirstChild();
-      if ($isCodeNode(firstChild) && firstChild.getLanguage() === "markdown") {
-        $convertFromMarkdownString(
-          firstChild.getTextContent(),
-          TRANSFORMERS,
-          undefined,
-          shouldPreserveNewLinesInMarkdown,
-        );
-      } else {
-        const markdown = $convertToMarkdownString(
-          TRANSFORMERS,
-          undefined,
-          shouldPreserveNewLinesInMarkdown,
-        );
-        const codeNode = $createCodeNode("markdown");
-        codeNode.append($createTextNode(markdown));
-        root.clear().append(codeNode);
-        if (markdown.length === 0) {
-          codeNode.select();
-        }
+export default function toggleMarkdown(editor: LexicalEditor, props: MarkdownProps) {
+  const { shouldPreserveNewLinesInMarkdown } = props;
+  editor.update(() => {
+    const root = $getRoot();
+    const firstChild = root.getFirstChild();
+    if ($isCodeNode(firstChild) && firstChild.getLanguage() === "markdown") {
+      $convertFromMarkdownString(
+        firstChild.getTextContent(),
+        TRANSFORMERS,
+        undefined,
+        shouldPreserveNewLinesInMarkdown,
+      );
+    } else {
+      const markdown = $convertToMarkdownString(
+        TRANSFORMERS,
+        undefined,
+        shouldPreserveNewLinesInMarkdown,
+      );
+      const codeNode = $createCodeNode("markdown");
+      codeNode.append($createTextNode(markdown));
+      root.clear().append(codeNode);
+      if (markdown.length === 0) {
+        codeNode.select();
       }
-    });
-  }, [editor, shouldPreserveNewLinesInMarkdown]);
-
-  return (
-    <div className="markdown-action">
-      <Button
-        className="markdown-toggle-button"
-        onClick={markdownToggle}
-        title="Convert From Markdown"
-      >
-        Toggle Markdown
-      </Button>
-    </div>
-  );
+    }
+  });
 }

--- a/examples/editor/src/plugins/MarkdownAction.tsx
+++ b/examples/editor/src/plugins/MarkdownAction.tsx
@@ -8,9 +8,12 @@ import { TRANSFORMERS } from "./transformers";
 
 export type MarkdownProps = {
   shouldPreserveNewLinesInMarkdown: boolean;
-}
+};
 
-export default function toggleMarkdown(editor: LexicalEditor, props: MarkdownProps) {
+export default function toggleMarkdown(
+  editor: LexicalEditor,
+  props: MarkdownProps,
+) {
   const { shouldPreserveNewLinesInMarkdown } = props;
   editor.update(() => {
     const root = $getRoot();

--- a/examples/editor/src/plugins/ToolbarPlugin.tsx
+++ b/examples/editor/src/plugins/ToolbarPlugin.tsx
@@ -35,6 +35,7 @@ import {
   DropdownItem,
   ToolbarWrapper,
 } from "../../../../packages/milkup-toolbar/src/index";
+import toggleMarkdown from "./MarkdownAction";
 
 export default function ToolbarPlugin() {
   const [editor] = useLexicalComposerContext();
@@ -73,6 +74,14 @@ export default function ToolbarPlugin() {
         label="Redo"
         icon="redo"
         isRedo={true}
+      />
+
+      <Divider />
+
+      <ToolbarButton
+       onClick={() => toggleMarkdown(editor, { shouldPreserveNewLinesInMarkdown: true })}
+       label="Markdown"
+       icon="markdown"
       />
 
       <Divider />

--- a/examples/editor/src/plugins/ToolbarPlugin.tsx
+++ b/examples/editor/src/plugins/ToolbarPlugin.tsx
@@ -79,9 +79,11 @@ export default function ToolbarPlugin() {
       <Divider />
 
       <ToolbarButton
-       onClick={() => toggleMarkdown(editor, { shouldPreserveNewLinesInMarkdown: true })}
-       label="Markdown"
-       icon="markdown"
+        onClick={() =>
+          toggleMarkdown(editor, { shouldPreserveNewLinesInMarkdown: true })
+        }
+        label="Markdown"
+        icon="markdown"
       />
 
       <Divider />

--- a/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
+++ b/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
@@ -88,7 +88,7 @@ type ParagraphPluginProps = {
  * additional paragraphspecified by the 'paragraph' `trailingLBMode`.
  */
 export default function ParagraphPlugin({
-  trailingLBMode = "paragraph",
+  trailingLBMode = "remove",
   paragraphModeExemption = ["listitem"],
 }: ParagraphPluginProps): JSX.Element | null {
   const [editor] = useLexicalComposerContext();


### PR DESCRIPTION
1. Moved markdown toggle to a toolbar button, and modified an SVG graphic to act as the icon (although if someone has a more appropriate one they are more than welcome to supply it)
2. Added a small left margin for the placeholder text so it doesn't clip into the cursor. No practical value, was just bothered by the original (magic value seems to be 16px).
3. Changed the default paragraph plugin mode to be `remove` instead of `paragraph`, since under `paragraph` the whitespace was arguably excessive.