### PR TITLE
Bug/carriage in math editor

### DIFF
--- a/packages/milkup-equations/src/EquationsPlugin.tsx
+++ b/packages/milkup-equations/src/EquationsPlugin.tsx
@@ -78,10 +78,7 @@ export default function EquationsPlugin(): JSX.Element | null {
           : $createBlockEquationNode(equation);
 
         $insertNodes([equationNode]);
-        // If inserted at the root, wrap in a paragraph.
-        if ($isRootOrShadowRoot(equationNode.getParentOrThrow())) {
-          $wrapNodeInElement(equationNode, $createParagraphNode).selectEnd();
-        }
+        equationNode.selectStart();
         return true;
       },
       COMMAND_PRIORITY_EDITOR,
@@ -283,13 +280,7 @@ export default function EquationsPlugin(): JSX.Element | null {
             );
             const equationNode = $createBlockEquationNode("");
             $insertNodes([equationNode]);
-            // If inserted at the root, wrap in a paragraph.
-            if ($isRootOrShadowRoot(equationNode.getParentOrThrow())) {
-              $wrapNodeInElement(
-                equationNode,
-                $createParagraphNode,
-              ).selectEnd();
-            }
+            equationNode.selectStart();
             return true;
           }
         }

--- a/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
+++ b/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
@@ -14,7 +14,7 @@ import {
 } from "lexical";
 import { CAN_USE_DOM } from "@lexical/utils";
 import { useCallback, useEffect } from "react";
-import { $isParagraphNode } from "lexical";
+import { $isParagraphNode, $isTextNode } from 'lexical';
 
 // Credit to a workaround found in https://github.com/facebook/lexical/issues/4358,
 // Lexical issue #4358, which as of now is still open, for the following code snippet
@@ -102,16 +102,18 @@ export default function ParagraphPlugin({
           return false;
         }
 
-        // Traverse upward to find the nearest paragraph node.
-        let paragraphNode = selection.focus.getNode();
-        while (paragraphNode && !$isParagraphNode(paragraphNode)) {
-          const parent = paragraphNode.getParent();
-          if (!parent) break;
-          paragraphNode = parent;
-        }
+        // If this node is a text node, and the parent node is a paragraph node
+        // whose parent is the root, then we can trigger custom behavior.
 
-        // Only trigger custom behavior if found paragraph is a direct child of the root.
-        if (paragraphNode && paragraphNode.getParent() === $getRoot()) {
+        const node = selection.focus.getNode();
+        const parent = node.getParent();
+        const parentsParent = parent?.getParent();
+
+        if (
+          $isTextNode(node) &&
+          $isParagraphNode(parent) &&
+          parentsParent === $getRoot()
+        ) {
           event.preventDefault();
           if (
             $isRangeSelection(selection) &&

--- a/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
+++ b/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
@@ -14,7 +14,7 @@ import {
 } from "lexical";
 import { CAN_USE_DOM } from "@lexical/utils";
 import { useCallback, useEffect } from "react";
-import { $isParagraphNode, $isTextNode } from 'lexical';
+import { $isParagraphNode, $isTextNode } from "lexical";
 
 // Credit to a workaround found in https://github.com/facebook/lexical/issues/4358,
 // Lexical issue #4358, which as of now is still open, for the following code snippet


### PR DESCRIPTION
Add stricter conditions for custom behaviour in `ParagraphPlugin` (only paragraphs whose parents are root are affected now), and remove wrapping of block equations in paragraphs from `INSERT_EQUATION_COMMAND` and `$$-<Enter>` listener.