### PR TITLE
Bug/safari paragraph plugin

### DIFF
--- a/examples/editor/src/Editor.tsx
+++ b/examples/editor/src/Editor.tsx
@@ -185,7 +185,8 @@ export default function Milkup() {
               <div className="editor-scroller">
                 <div className="editor-input" ref={onRef}>
                   {/*
-                  // @ts-expect-error Probably caused by React version differences between examples/editor and milkup packages. */}
+                  // @ts-expect-error 
+                  // Probably caused by React version differences between examples/editor and milkup packages. */}
                   <ContentEditable
                     aria-placeholder="Explore!"
                     placeholder={

--- a/packages/milkup-equations/src/EquationsPlugin.tsx
+++ b/packages/milkup-equations/src/EquationsPlugin.tsx
@@ -143,6 +143,7 @@ export default function EquationsPlugin(): JSX.Element | null {
             }
           }
           // For non-first code-highlight, let default behavior preserve position.
+          return false;
         }
       });
       return true;
@@ -268,12 +269,10 @@ export default function EquationsPlugin(): JSX.Element | null {
         }
         // Only trigger custom behavior if found paragraph is a direct child of the root.
         if (paragraphNode && paragraphNode.getParent() === $getRoot()) {
-          event.preventDefault();
           const focusNode = selection.focus.getNode();
           if (focusNode.getType() !== "text") {
             return false;
           }
-          console.log(focusNode.getTextContent().trim());
           if (focusNode.getTextContent().trim().endsWith("$$")) {
             (focusNode as TextNode).setTextContent(
               focusNode.getTextContent().replace(/\$\$\s*$/, ""),

--- a/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
+++ b/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
@@ -111,8 +111,8 @@ export default function ParagraphPlugin({
 
         if (
           ($isTextNode(node) &&
-          $isParagraphNode(parent) &&
-          parentsParent === $getRoot()) ||
+            $isParagraphNode(parent) &&
+            parentsParent === $getRoot()) ||
           ($isParagraphNode(node) && parent === $getRoot())
         ) {
           console.log("Paragraph node found");

--- a/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
+++ b/packages/milkup-paragraphs/src/ParagraphPlugin.tsx
@@ -110,10 +110,12 @@ export default function ParagraphPlugin({
         const parentsParent = parent?.getParent();
 
         if (
-          $isTextNode(node) &&
+          ($isTextNode(node) &&
           $isParagraphNode(parent) &&
-          parentsParent === $getRoot()
+          parentsParent === $getRoot()) ||
+          ($isParagraphNode(node) && parent === $getRoot())
         ) {
+          console.log("Paragraph node found");
           event.preventDefault();
           if (
             $isRangeSelection(selection) &&


### PR DESCRIPTION
Fix a bug where `ENTER` in Safari would not produce new lines. Also fix an issue with `ParagraphPlugin` (that I caused last night, sorry!) where the `remove` option was leaving trailing LBs.